### PR TITLE
Keep previous display in case of poll error

### DIFF
--- a/solrpi/fronius_inverter.py
+++ b/solrpi/fronius_inverter.py
@@ -33,4 +33,4 @@ class FroniusInverter(Inverter):
             return [grid, pv]
         except requests.exceptions.RequestException as err:
             logger.error("An error occurred reading Fronius at URL '{}'. Will keep trying. Error: '{}'", self.url, err)
-            return [0, 0]
+            raise err

--- a/solrpi/i_inverter.py
+++ b/solrpi/i_inverter.py
@@ -8,5 +8,6 @@ class Inverter:
     # get_watt() returns array with two values: grid, pv (unit [Watt])
     # pv is always positive
     # grid<0 == pv into grid; grid>0 == grid consumption
+    # raises an exception in case of error
     def get_watt(self):
         pass


### PR DESCRIPTION
Previously, when the inverter polling raises an error, the display went blank. Instead of blanking the screen, the previous display is kept, assuming the error is only temporary.